### PR TITLE
Use built-in Yarn binary instead of borales/actions-yarn

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,17 +11,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - uses: borales/actions-yarn@v2.0.0
-        with:
-          cmd: install
+      - run: yarn install
 
-      - uses: borales/actions-yarn@v2.0.0
-        with:
-          cmd: build
+      - run: yarn build
 
-      - uses: borales/actions-yarn@v2.0.0
-        with:
-          cmd: clean
+      - run: yarn clean
 
       - name: Publish if version has been updated
         uses: pascalgn/npm-publish-action@1.3.6


### PR DESCRIPTION
GitHub Actions Runners come with Yarn built-in so using a third-party action isn't necessary. This should speed up builds as this also skips installing Yarn again.